### PR TITLE
fix(Footer): use Children.toArray

### DIFF
--- a/src/components/interface/Footer/Footer.js
+++ b/src/components/interface/Footer/Footer.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { Children } from 'react';
+
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import dataAttributes from '../../../utils/data-attributes';
@@ -6,8 +7,8 @@ import dataAttributes from '../../../utils/data-attributes';
 import '@gouvfr/dsfr/dist/css/footer.min.css';
 
 const Footer = ({ children, className, ...remainingProps }) => {
-  const top = children.filter((child) => child.props.__TYPE === 'FooterTop');
-  const rest = children.filter((child) => child.props.__TYPE !== 'FooterTop');
+  const top = Children.toArray(children).filter((child) => child.props.__TYPE === 'FooterTop');
+  const rest = Children.toArray(children).filter((child) => child.props.__TYPE !== 'FooterTop');
   const _className = classNames('fr-footer', className);
   return (
     <footer

--- a/src/components/interface/Footer/FooterBottom.js
+++ b/src/components/interface/Footer/FooterBottom.js
@@ -9,7 +9,7 @@ const FooterBottom = ({ children, className, ...remainingProps }) => {
   const links = Children.toArray(children)
     .filter((link) => link.props.__TYPE === 'FooterLink')
     .map((link) => cloneElement(link, { section: 'bottom' }));
-  const childs = children.filter((link) => link.props.__TYPE !== 'FooterLink');
+  const childs = Children.toArray(children).filter((link) => link.props.__TYPE !== 'FooterLink');
   return (
     <div
       className={classNames('fr-footer__bottom', className)}

--- a/src/components/interface/Footer/FooterPartners.js
+++ b/src/components/interface/Footer/FooterPartners.js
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, { Children } from "react";
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import dataAttributes from '../../../utils/data-attributes';
 import typeValidation from '../../../utils/type-validation';
 
 const FooterPartners = ({ children, className, ...remainingProps }) => {
-  const title = children.filter(
+  const title = Children.toArray(children).filter(
     (child) => child.props.__TYPE === 'FooterPartnersTitle',
   );
-  const mainLogos = children.filter(
+  const mainLogos = Children.toArray(children).filter(
     (child) => child.props.__TYPE === 'FooterPartnersLogo' && child.props.isMain,
   );
-  const subLogos = children.filter(
+  const subLogos = Children.toArray(children).filter(
     (child) => child.props.__TYPE === 'FooterPartnersLogo' && !child.props.isMain,
   );
   return (


### PR DESCRIPTION
prevent exceptions when there is only one child (ex: no `FooterBottom`)