### PR TITLE
fix: optional logo in Header and Footer

### DIFF
--- a/src/components/interface/Footer/FooterBody.js
+++ b/src/components/interface/Footer/FooterBody.js
@@ -18,7 +18,7 @@ const FooterBody = ({
       className={classNames('fr-footer__body', className)}
       {...dataAttributes.getAll(remainingProps)}
     >
-      { Logo ? <div className="fr-footer__brand">{Logo}</div> : null}
+      { Logo && <div className="fr-footer__brand">{Logo}</div> || null}
       <div className="fr-footer__content">
         <p className="fr-footer__content-desc">{description}</p>
         <ul className="fr-footer__content-list">

--- a/src/components/interface/Footer/FooterBody.js
+++ b/src/components/interface/Footer/FooterBody.js
@@ -18,7 +18,7 @@ const FooterBody = ({
       className={classNames('fr-footer__body', className)}
       {...dataAttributes.getAll(remainingProps)}
     >
-      { Logo && <div className="fr-footer__brand">{Logo}</div> || null}
+      {Logo && <div className="fr-footer__brand">{Logo}</div> || null}
       <div className="fr-footer__content">
         <p className="fr-footer__content-desc">{description}</p>
         <ul className="fr-footer__content-list">

--- a/src/components/interface/Footer/FooterBody.js
+++ b/src/components/interface/Footer/FooterBody.js
@@ -18,7 +18,7 @@ const FooterBody = ({
       className={classNames('fr-footer__body', className)}
       {...dataAttributes.getAll(remainingProps)}
     >
-      <div className="fr-footer__brand">{Logo}</div>
+      { Logo ? <div className="fr-footer__brand">{Logo}</div> : null}
       <div className="fr-footer__content">
         <p className="fr-footer__content-desc">{description}</p>
         <ul className="fr-footer__content-list">

--- a/src/components/interface/Header/HeaderBody.js
+++ b/src/components/interface/Header/HeaderBody.js
@@ -35,9 +35,11 @@ const HeaderBody = ({
         <div className={classNames(className, 'fr-header__body-row')}>
           <div className="fr-header__brand fr-enlarge-link">
             <div className="fr-header__brand-top">
+              {logo && (
               <div className="fr-header__logo">
                 {logo}
               </div>
+              )}
               {headerOperator}
               {(isNavBar || isNavTool) && (
                 <div className="fr-header__navbar">

--- a/src/components/interface/Header/HeaderBody.js
+++ b/src/components/interface/Header/HeaderBody.js
@@ -39,7 +39,7 @@ const HeaderBody = ({
               <div className="fr-header__logo">
                 {logo}
               </div>
-              )}
+              ) || null}
               {headerOperator}
               {(isNavBar || isNavTool) && (
                 <div className="fr-header__navbar">


### PR DESCRIPTION
Ne produit pas les wrappers `.fr-header__logo` et `fr-footer__brand` qui occupe un espace vide si l'utilisateur ne fournit pas de composant `Logo` dans `HeaderBody` et `FooterBody`

cas d'usage : utilisation du dsfr hors charte "marianne"