### PR TITLE
move window call from useState to useEffect

### DIFF
--- a/src/hooks/useViewport.js
+++ b/src/hooks/useViewport.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 const useViewport = () => {
-  const [size, setSize] = React.useState({width: null, height: null});
+  const [size, setSize] = useState({width: null, height: null});
 
   useEffect(() => {
     const handleWindowResize = () => {


### PR DESCRIPTION
Lorsqu'on utilise un framework faisant du SSR comme NextJS, l'usage de `window` hors de `useEffect` est problématique car c'est exécuté côté serveur ou `window` n'existe pas.

Le problème s'est présenté pour moi dans le hook `useViewport` qui n'est utilisé que dans le composant `Header` il me semble

Je vous propose ce fix qui il me semble permettra d'initialiser la valeur de `width` et `height` lors du `mount` du composant. J'ai un petit doute que cela cause un blink au chargement de la page, à vérifier.

Merci pour ce repo 🙇 