### PR TITLE
build: transpile nullish coalescing operators to ensure es2019 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@axe-core/react": "^4.2.2",
         "@babel/cli": "^7.14.8",
         "@babel/core": "^7.15.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-transform-runtime": "^7.15.0",
         "@babel/preset-env": "^7.15.0",
         "@babel/preset-react": "^7.14.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@axe-core/react": "^4.2.2",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.15.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ MODE.forEach((m) => {
     plugins: [
       babel({
         exclude: 'node_modules/**',
-        plugins: ['@babel/transform-runtime'],
+        plugins: ['@babel/transform-runtime', '@babel/plugin-proposal-nullish-coalescing-operator'],
         babelHelpers: 'runtime',
       }),
       postcss({


### PR DESCRIPTION
Fixes #203.

Il suffit d'imposer à `rollup` de transpiler les `??` (il y en a qu'un seul, mais on peut désormais ne pas s'en priver!).