### PR TITLE
fix: remove tag size lg

### DIFF
--- a/src/components/interface/Tag/Tag.js
+++ b/src/components/interface/Tag/Tag.js
@@ -78,7 +78,7 @@ Tag.propTypes = {
   ]),
   as: PropTypes.oneOf(['a', 'span', 'p']),
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['sm', 'md']),
   href: PropTypes.string,
   title: PropTypes.string,
   target: PropTypes.string,


### PR DESCRIPTION
Unfortunately there are only two tag sizes : `sm` and `md` cf https://gouvfr.atlassian.net/wiki/spaces/DB/pages/310706305/Tag