### PR TITLE
fix(Header): prevent exception when no logo

### DIFF
--- a/src/components/interface/Header/HeaderBody.js
+++ b/src/components/interface/Header/HeaderBody.js
@@ -13,9 +13,9 @@ const HeaderBody = ({
     children,
     (child) => child.type && !managedTypes.includes(child.props.__TYPE),
   );
-  const logo = deepFilter(children, (child) => child.type && child.props.__TYPE === 'Logo');
-  const service = deepFilter(children, (child) => child.type && child.props.__TYPE === 'Service');
-  const headerOperator = Children.toArray(children).find((child) => child.type && child.props.__TYPE === 'HeaderOperator');
+  const logo = deepFilter(children, (child) => child.type && child.props && child.props.__TYPE === 'Logo');
+  const service = deepFilter(children, (child) => child.type && child.props && child.props.__TYPE === 'Service');
+  const headerOperator = Children.toArray(children).find((child) => child.type && child.props && child.props.__TYPE === 'HeaderOperator');
 
   const context = useContext(HeaderContext);
   const {


### PR DESCRIPTION
Prevent an exception when no Logo is provided in the Header

```
Error occurred prerendering page "/url/xxx/yyy". Read more: https://nextjs.org/docs/messages/prerender-error
TypeError: Cannot read property '__TYPE' of undefined
    at /Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/@dataesr/react-dsfr/dist/index.min.cjs.js:1:76843
    at Array.filter (<anonymous>)
    at Ne (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/@dataesr/react-dsfr/dist/index.min.cjs.js:1:76800)
    at d (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:33:498)
    at bb (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:36:16)
    at a.b.render (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:42:43)
    at a.b.read (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:41:83)
    at Object.exports.renderToString (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:52:138)
    at Object.renderPage (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/next/dist/server/render.js:736:46)
    at Object.defaultGetInitialProps (/Users/julienb/projects/mas/dashlord/dashlord-actions/report/www/node_modules/next/dist/server/render.js:368:51)
info  - Generating static pages (88/88)
```

