### PR TITLE
feat(callout): allow div in callout text to allow complex markup

### DIFF
--- a/src/components/interface/Callout/CalloutText.d.ts
+++ b/src/components/interface/Callout/CalloutText.d.ts
@@ -6,7 +6,7 @@ export type CalloutTextClassName = string | Object | any[];
 
 export type CalloutTextSize = "xs" | "sm" | "md" | "lg" | "xl";
 
-export type CalloutTextAs = "p" | "ul";
+export type CalloutTextAs = "p" | "ul" | "div";
 
 export interface CalloutTextProps {
     children: CalloutTextChildren;

--- a/src/components/interface/Callout/CalloutText.js
+++ b/src/components/interface/Callout/CalloutText.js
@@ -31,7 +31,7 @@ CalloutText.propTypes = {
     PropTypes.object,
     PropTypes.array,
   ]),
-  as: PropTypes.oneOf(['p', 'ul']),
+  as: PropTypes.oneOf(['p', 'ul', 'div']),
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };
 CalloutText.defaultProps = {


### PR DESCRIPTION
Today, if we had complex markup in callout text, we endup with an invalid html

![Screenshot from 2022-03-01 21-26-51](https://user-images.githubusercontent.com/4971715/156243660-d21112d4-07b1-4b21-a799-064c1f9ebebf.png)