### PR TITLE
feat: allow custom icons in call outs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataesr/react-dsfr",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "private": false,
   "description": "A React implementation of the french government design system.",
   "license": "MIT",

--- a/src/components/interface/Callout/Callout.js
+++ b/src/components/interface/Callout/Callout.js
@@ -12,13 +12,20 @@ import '@gouvfr/dsfr/dist/component/callout/callout.css';
  * @visibleName Callout
  */
 const Callout = ({
-  hasInfoIcon, children, className, colorFamily, colors, ...remainingProps
+  hasInfoIcon, icon, children, className, colorFamily, colors, ...remainingProps
 }) => {
+  if (!hasInfoIcon) { // TODO Delete deprecated prop hasInfoIcon when reaching major version 4.0.0
+    // eslint-disable-next-line no-console
+    console.warn("'hasInfoIcon' is deprecated and will be deleted in version 4.0.0. Please use 'icon' instead", hasInfoIcon);
+    // eslint-disable-next-line no-param-reassign
+    icon = undefined;
+  }
+
   const theme = useTheme();
   const [color, backgroundColor] = colors;
   const calloutRef = useRef();
   const _className = classNames('fr-callout', className, {
-    'fr-fi-information-line': hasInfoIcon,
+    [`fr-fi-${icon}`]: icon,
     [`fr-callout--${colorFamily}`]: colorFamily,
   });
 
@@ -45,6 +52,7 @@ const Callout = ({
 };
 
 Callout.defaultProps = {
+  icon: 'information-line',
   hasInfoIcon: true,
   className: '',
   colors: [],
@@ -52,6 +60,7 @@ Callout.defaultProps = {
 };
 
 Callout.propTypes = {
+  icon: PropTypes.string,
   hasInfoIcon: PropTypes.bool,
   colorFamily: PropTypes.oneOf([...colorFamilies, '']),
   /**


### PR DESCRIPTION
Les eslint-disable ne sont normalement pas best practice mais ils me semblent coherent dans ce context