### PR TITLE
fix(Tab): fix TS definitions

### DIFF
--- a/src/components/interface/Tabs/Tab.d.ts
+++ b/src/components/interface/Tabs/Tab.d.ts
@@ -7,6 +7,8 @@ export interface TabProps {
   children?: TabChildren;
   index: number;
   activeTab: number;
+  label: string;
+  icon?: string;
 }
 
 declare const Tab: React.FC<TabProps>;

--- a/src/components/interface/Tabs/Tab.js
+++ b/src/components/interface/Tabs/Tab.js
@@ -25,10 +25,13 @@ const Tab = ({
 
 Tab.defaultProps = {
   className: '',
+  icon: '',
 };
 
 Tab.propTypes = {
   className: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  icon: PropTypes.string,
   index: PropTypes.number.isRequired,
   activeTab: PropTypes.number.isRequired,
   children: PropTypes.oneOfType([


### PR DESCRIPTION
Sauf erreur, les tabs peuvent être utilisés comme ceci :

```jsx
<Tabs defaultActiveTab={0}>
    <Tab label="Formulaire">blabla</Tab>
    <Tab label="Algo">blabla</Tab>
</Table>
```

Or il semble que `label` et `icon` ne soient pas définies en TS