### PR TITLE
fix(Footer): :bug: Fix "filter" bug when FooterTopCategory has only o…

### DIFF
--- a/src/components/interface/Footer/FooterTopCategory.js
+++ b/src/components/interface/Footer/FooterTopCategory.js
@@ -9,10 +9,11 @@ import typeValidation from '../../../utils/type-validation';
 const FooterTopCategory = ({
   children, title, n, offset, className, ...remainingProps
 }) => {
-  const links = Children.toArray(children)
+  const childrenArray = Children.toArray(children);
+  const links = childrenArray
     .filter((link) => link && link.props.__TYPE === 'FooterLink')
     .map((link) => cloneElement(link, { section: 'top' }));
-  const childs = children.filter((link) => link.props.__TYPE !== 'FooterLink');
+  const childs = childrenArray.filter((link) => link.props.__TYPE !== 'FooterLink');
   return (
     <Col
       n={n}

--- a/src/components/interface/Footer/__tests__/Footer.test.js
+++ b/src/components/interface/Footer/__tests__/Footer.test.js
@@ -98,4 +98,56 @@ describe('<Footer />', () => {
     const footer = screen.getByTestId('footer');
     expect(footer).toMatchSnapshot();
   });
+  it('should render Footer properly with only one child under FooterTopCategory', () => {
+    render(
+      <Footer data-testid="footer">
+        <FooterTop data-testid="footertop">
+          <FooterTopCategory title="Nom de la catégorie" data-testid="footertopcategory">
+            <FooterLink href="/" data-testid="footerlink">Lien de navigation</FooterLink>
+          </FooterTopCategory>
+        </FooterTop>
+        <FooterBody
+          description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Uenim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+          data-testid="footerbody"
+        >
+          <Logo splitCharacter={10} data-testid="footerlogo">
+            Ministère de l&apos;enseignement supérieur de la rechercher et de l&apos;innovation
+          </Logo>
+          <FooterOperator>
+            <img src="https://fakeimg.pl/145x81/" alt="texte alternatif" />
+          </FooterOperator>
+          <FooterBodyItem>
+            legifrance.gouv.fr
+          </FooterBodyItem>
+          <FooterBodyItem>
+            gouvernement.fr
+          </FooterBodyItem>
+          <FooterBodyItem>
+            service-public.fr
+          </FooterBodyItem>
+          <FooterBodyItem>
+            data.gouv.fr
+          </FooterBodyItem>
+        </FooterBody>
+        <FooterPartners data-testid="footerpartners">
+          <FooterPartnersTitle data-testid="title">Nos partenaires</FooterPartnersTitle>
+          <FooterPartnersSecondaryTitle data-testid="title">Et plus...</FooterPartnersSecondaryTitle>
+          <FooterPartnersLogo isMain href="/" imageSrc="img/logo1" imageAlt="Logo 1" data-testid="logo" />
+          <FooterPartnersLogo href="/" imageSrc="img/logo2" imageAlt="Logo 2" />
+          <FooterPartnersLogo href="/" imageSrc="img/logo3" imageAlt="Logo 3" />
+          <FooterPartnersLogo href="/" imageSrc="img/logo4" imageAlt="Logo 4" />
+        </FooterPartners>
+        <FooterBottom data-testid="bottom">
+          <FooterLink href="/" data-testid="link">Plan du site</FooterLink>
+          <FooterLink href="/">Accessibilité: non/partiellement/totalement conforme</FooterLink>
+          <FooterLink href="/">Mentions légales</FooterLink>
+          <FooterLink href="/">Données personnelles</FooterLink>
+          <FooterLink href="/">Gestion des cookies</FooterLink>
+          <FooterCopy href="/">© République Française 2020</FooterCopy>
+        </FooterBottom>
+      </Footer>,
+    );
+    const footer = screen.getByTestId('footer');
+    expect(footer).toMatchSnapshot();
+  });
 });

--- a/src/components/interface/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/components/interface/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -575,3 +575,296 @@ exports[`<Footer /> should render Footer properly 1`] = `
   </div>
 </footer>
 `;
+
+exports[`<Footer /> should render Footer properly 2`] = `
+<footer
+  class="fr-footer"
+  data-testid="footer"
+  id="footer"
+  role="contentinfo"
+>
+  <div
+    class="fr-footer__top"
+    data-testid="footertop"
+  >
+    <div
+      class="fr-container"
+    >
+      <div
+        class="fr-grid-row fr-grid-row--center fr-grid-row--gutters"
+      >
+        <div
+          class="fr-col-12 fr-col-sm-4 fr-col-md-2"
+        >
+          <div
+            class="fr-footer__top-cat"
+          >
+            Nom de la catégorie
+          </div>
+          <ul
+            class="fr-footer__top-list"
+          >
+            <li
+              class="fr-footer__top-item"
+              data-testid="footerlink"
+            >
+              <a
+                class="fr-footer__top-link fr-link--md"
+                href="/"
+                target="_self"
+              >
+                Lien de navigation
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="fr-container"
+  >
+    <div
+      class="fr-footer__body"
+      data-testid="footerbody"
+    >
+      <div
+        class="fr-footer__brand fr-enlarge-link"
+      >
+        <a
+          class="fr-link--md"
+          data-testid="footerlogo"
+          href="/"
+          target="_self"
+          title="Ministère de l'enseignement supérieur de la rechercher et de l'innovation"
+        >
+          <p
+            class="fr-logo"
+          >
+            Ministère de
+            <br />
+            l'enseignement
+            <br />
+            supérieur de
+            <br />
+            la rechercher
+            <br />
+            et de l'innovation
+          </p>
+        </a>
+      </div>
+      <div
+        class="fr-footer__brand-link"
+      >
+        <img
+          alt="texte alternatif"
+          src="https://fakeimg.pl/145x81/"
+        />
+      </div>
+      <div
+        class="fr-footer__content"
+      >
+        <p
+          class="fr-footer__content-desc"
+        >
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Uenim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+        <ul
+          class="fr-footer__content-list"
+        >
+          <li
+            class="fr-footer__content-item"
+          >
+            <div
+              class="fr-footer__content-link"
+            >
+              legifrance.gouv.fr
+            </div>
+          </li>
+          <li
+            class="fr-footer__content-item"
+          >
+            <div
+              class="fr-footer__content-link"
+            >
+              gouvernement.fr
+            </div>
+          </li>
+          <li
+            class="fr-footer__content-item"
+          >
+            <div
+              class="fr-footer__content-link"
+            >
+              service-public.fr
+            </div>
+          </li>
+          <li
+            class="fr-footer__content-item"
+          >
+            <div
+              class="fr-footer__content-link"
+            >
+              data.gouv.fr
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="fr-footer__partners"
+      data-testid="footerpartners"
+    >
+      <div
+        class="fr-footer__partners-logos"
+      >
+        <div
+          class="fr-footer__partners-main"
+        >
+          <div>
+            <h4
+              class="fr-footer__partners-title"
+              data-testid="title"
+            >
+              Nos partenaires
+            </h4>
+            <a
+              class="fr-footer__partners-link fr-link--md"
+              data-testid="logo"
+              href="/"
+              target="_self"
+            >
+              <img
+                alt="Logo 1"
+                class="fr-footer__logo"
+                src="img/logo1"
+              />
+            </a>
+          </div>
+        </div>
+        <div
+          class="fr-footer__partners-sub"
+        >
+          <ul>
+            <li>
+              <h4
+                class="fr-footer__partners-title"
+                data-testid="title"
+              >
+                Et plus...
+              </h4>
+              <a
+                class="fr-footer__partners-link fr-link--md"
+                href="/"
+                target="_self"
+              >
+                <img
+                  alt="Logo 2"
+                  class="fr-footer__logo"
+                  src="img/logo2"
+                />
+              </a>
+            </li>
+            <li>
+              <a
+                class="fr-footer__partners-link fr-link--md"
+                href="/"
+                target="_self"
+              >
+                <img
+                  alt="Logo 3"
+                  class="fr-footer__logo"
+                  src="img/logo3"
+                />
+              </a>
+            </li>
+            <li>
+              <a
+                class="fr-footer__partners-link fr-link--md"
+                href="/"
+                target="_self"
+              >
+                <img
+                  alt="Logo 4"
+                  class="fr-footer__logo"
+                  src="img/logo4"
+                />
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fr-footer__bottom"
+      data-testid="bottom"
+    >
+      <ul
+        class="fr-footer__bottom-list"
+      >
+        <li
+          class="fr-footer__bottom-item"
+          data-testid="link"
+        >
+          <a
+            class="fr-footer__bottom-link fr-link--md"
+            href="/"
+            target="_self"
+          >
+            Plan du site
+          </a>
+        </li>
+        <li
+          class="fr-footer__bottom-item"
+        >
+          <a
+            class="fr-footer__bottom-link fr-link--md"
+            href="/"
+            target="_self"
+          >
+            Accessibilité: non/partiellement/totalement conforme
+          </a>
+        </li>
+        <li
+          class="fr-footer__bottom-item"
+        >
+          <a
+            class="fr-footer__bottom-link fr-link--md"
+            href="/"
+            target="_self"
+          >
+            Mentions légales
+          </a>
+        </li>
+        <li
+          class="fr-footer__bottom-item"
+        >
+          <a
+            class="fr-footer__bottom-link fr-link--md"
+            href="/"
+            target="_self"
+          >
+            Données personnelles
+          </a>
+        </li>
+        <li
+          class="fr-footer__bottom-item"
+        >
+          <a
+            class="fr-footer__bottom-link fr-link--md"
+            href="/"
+            target="_self"
+          >
+            Gestion des cookies
+          </a>
+        </li>
+      </ul>
+      <div
+        class="fr-footer__bottom-copy"
+      >
+        © République Française 2020
+      </div>
+    </div>
+  </div>
+</footer>
+`;


### PR DESCRIPTION
There is an issue there when the Category contains only one element.

See : https://github.com/dataesr/react-dsfr/blob/31502939cf5e611b6b3c32649d107b334fb550d2/src/components/interface/Footer/FooterTopCategory.js#L15

Could be solved by making sure to have an array  : 

```js
 const childrenArray = Children.toArray(children);
  const links = childrenArray
    .filter((link) => link && link.props.__TYPE === 'FooterLink')
    .map((link) => cloneElement(link, { section: 'top' }));
  const childs = childrenArray.filter((link) => link.props.__TYPE !== 'FooterLink');
```