### PR TITLE
fix: :technologist: Improvement of the APIs of ConsentManager & ConsentService to be able to manage consents correctly

### DIFF
--- a/src/components/interface/ConsentManager/ConsentManager.d.ts
+++ b/src/components/interface/ConsentManager/ConsentManager.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-export type ConsentManagerChildren = React.ReactNode[] | React.ReactElement<any>;
+export type ConsentManagerChildren =
+  | React.ReactNode[]
+  | React.ReactElement<any>;
 
 export interface ConsentManagerBannerButtons {
   refuse?: {
@@ -15,21 +17,22 @@ export interface ConsentManagerBannerButtons {
 }
 
 export interface ConsentManagerProps {
+  acceptBannerButton: (...args: any[]) => any;
+  bannerButtons: ConsentManagerBannerButtons;
+  bannerDescription: string;
+  bannerTitle?: string;
   children: ConsentManagerChildren;
-  isModalOpen: boolean;
-  isBannerOpen?: boolean;
   confirmButtonLabel?: string;
   confirmButtonTitle?: string;
-  bannerDescription: string;
-  modalTitle: string;
+  confirmConsent: (...args: any[]) => any;
+  isBannerOpen?: boolean;
+  isModalOpen: boolean;
   modalCloseLabel: string;
   modalCloseTitle: string;
-  bannerTitle?: string;
-  setIsModalOpen: (...args: any[])=>any;
-  confirmConsent: (...args: any[])=>any;
-  refuseBannerButton: (...args: any[])=>any;
-  acceptBannerButton: (...args: any[])=>any;
-  bannerButtons: ConsentManagerBannerButtons;
+  modalTitle: string;
+  name: string;
+  refuseBannerButton: (...args: any[]) => any;
+  setIsModalOpen: (...args: any[]) => any;
 }
 
 declare const ConsentManager: React.FC<ConsentManagerProps>;

--- a/src/components/interface/ConsentManager/ConsentManager.js
+++ b/src/components/interface/ConsentManager/ConsentManager.js
@@ -30,7 +30,7 @@ const ConsentManager = ({
     const responseObject = {};
     service.map((c) => {
       const input = c.ref.current.querySelector('input');
-      responseObject[input.value] = input.checked;
+      responseObject[input.name] = input.checked;
       return input.checked;
     });
     confirmConsent(responseObject);
@@ -39,14 +39,14 @@ const ConsentManager = ({
   return (
     <>
       {isBannerOpen && (
-      <ConsentBanner
-        acceptBannerButton={acceptBannerButton}
-        refuseBannerButton={refuseBannerButton}
-        bannerButtons={bannerButtons}
-        openConsentModal={openConsentModal}
-        title={bannerTitle}
-        description={bannerDescription}
-      />
+        <ConsentBanner
+          acceptBannerButton={acceptBannerButton}
+          refuseBannerButton={refuseBannerButton}
+          bannerButtons={bannerButtons}
+          openConsentModal={openConsentModal}
+          title={bannerTitle}
+          description={bannerDescription}
+        />
       )}
       <ConsentModal
         confirmConsent={manageDataConsent}

--- a/src/components/interface/ConsentManager/ConsentManager.stories.tsx
+++ b/src/components/interface/ConsentManager/ConsentManager.stories.tsx
@@ -1,0 +1,145 @@
+import { ComponentStory } from '@storybook/react';
+
+import ConsentManager from './ConsentManager';
+import ConsentService from './ConsentService';
+
+export default {
+  title: 'ConsentManager',
+  component: ConsentManager,
+  subcomponents: { ConsentService },
+};
+
+const Template: ComponentStory<typeof ConsentManager> = (args) => (
+  <ConsentManager {...args} />
+);
+
+export const SimpleConsentManager = Template.bind({});
+SimpleConsentManager.args = {
+  bannerDescription:
+    'Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les services disponibles sur ce site. Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.',
+  bannerTitle: 'À propos des cookies sur refugies.info',
+  bannerButtons: {
+    accept: {
+      label: 'Tout Accepter',
+    },
+    refuse: {
+      label: 'Tout Refuser',
+    },
+    customize: {
+      label: 'Personnaliser',
+    },
+  },
+  modalTitle: 'Panneau de gestion des cookies',
+  modalCloseLabel: 'Fermer',
+  modalCloseTitle: 'fermer la modal cookie',
+  confirmButtonLabel: 'Confirmer mes choix',
+
+  acceptBannerButton: () => console.log('acceptBannerButton'),
+  refuseBannerButton: () => console.log('refuseBannerButton'),
+  isModalOpen: false,
+  setIsModalOpen: () => console.log('setIsModalOpen'),
+  confirmConsent: (value) => console.log('confirmConsent', value),
+
+  children: [
+    <ConsentService
+      description=""
+      name="all"
+      title="Préférences pour tous les services."
+      acceptLabel="Tout accepter"
+      refuseLabel="Tout refuser"
+      defaultConsent="refuse"
+    />,
+    <ConsentService
+      description="Ce site utilise des cookies nécessaires à son bon fonctionnement qui ne peuvent pas être désactivés."
+      name="mandatory"
+      title="Cookies obligatoires"
+      acceptLabel="Accepter"
+      refuseLabel="Refuser"
+      defaultConsent="accept"
+    />,
+    <ConsentService
+      description="Identifie les visiteurs en provenance de publications Facebook."
+      name="facebook"
+      title="Facebook Pixel"
+      acceptLabel="Accepter"
+      refuseLabel="Refuser"
+      defaultConsent="refuse"
+    />,
+    <ConsentService
+      description="Permet d'analyser les statistiques de consultation de notre site."
+      name="google_analytics"
+      title="Google Analytics"
+      acceptLabel="Accepter"
+      refuseLabel="Refuser"
+      defaultConsent="accept"
+    />,
+  ],
+};
+SimpleConsentManager.storyName = 'ConsentManager';
+
+export const ModalOpenedConsentManager = Template.bind({});
+ModalOpenedConsentManager.args = {
+  bannerDescription:
+    'Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les services disponibles sur ce site. Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.',
+  bannerTitle: 'À propos des cookies sur refugies.info',
+  bannerButtons: {
+    accept: {
+      label: 'Tout Accepter',
+    },
+    refuse: {
+      label: 'Tout Refuser',
+    },
+    customize: {
+      label: 'Personnaliser',
+    },
+  },
+  modalTitle: 'Panneau de gestion des cookies',
+  modalCloseLabel: 'Fermer',
+  modalCloseTitle: 'fermer la modal cookie',
+  confirmButtonLabel: 'Confirmer mes choix',
+
+  acceptBannerButton: () => console.log('acceptBannerButton'),
+  refuseBannerButton: () => console.log('refuseBannerButton'),
+  isModalOpen: true,
+  setIsModalOpen: (value) => console.log('setIsModalOpen', value),
+  confirmConsent: (value) => console.log('confirmConsent', value),
+  isBannerOpen: false,
+
+  children: [
+    <ConsentService
+      description=""
+      name="all"
+      title="Préférences pour tous les services."
+      acceptLabel="Tout accepter"
+      refuseLabel="Tout refuser"
+      defaultConsent="refuse"
+      onChange={(e) => console.log('onChange', e)}
+    />,
+    <ConsentService
+      acceptLabel="Accepter"
+      defaultConsent="accept"
+      description="Ce site utilise des cookies nécessaires à son bon fonctionnement qui ne peuvent pas être désactivés."
+      disabled
+      name="mandatory"
+      refuseLabel="Refuser"
+      title="Cookies obligatoires"
+    />,
+    <ConsentService
+      description="Identifie les visiteurs en provenance de publications Facebook."
+      name="facebook"
+      title="Facebook Pixel"
+      acceptLabel="Accepter"
+      refuseLabel="Refuser"
+      defaultConsent="refuse"
+    />,
+    <ConsentService
+      description="Permet d'analyser les statistiques de consultation de notre site."
+      name="google_analytics"
+      title="Google Analytics"
+      acceptLabel="Accepter"
+      refuseLabel="Refuser"
+      defaultConsent="accept"
+    />,
+  ],
+};
+ModalOpenedConsentManager.storyName = 'ConsentManagerModalOpen';

--- a/src/components/interface/ConsentManager/ConsentService.d.ts
+++ b/src/components/interface/ConsentManager/ConsentService.d.ts
@@ -3,12 +3,15 @@ import * as React from 'react';
 export type ConsentServiceDefaultConsent = 'accept' | 'refuse';
 
 export interface ConsentServiceProps {
+  acceptLabel: string;
   className?: string;
-  title: string;
   defaultConsent: ConsentServiceDefaultConsent;
   description?: string;
-  acceptLabel: string;
+  disabled?: boolean;
+  name?: string;
+  onChange?: (...args: any[]) => any;
   refuseLabel: string;
+  title: string;
 }
 
 declare const ConsentService: React.FC<ConsentServiceProps>;

--- a/src/components/interface/ConsentManager/ConsentService.js
+++ b/src/components/interface/ConsentManager/ConsentService.js
@@ -6,15 +6,21 @@ import { RadioGroup, Radio } from '../Radio';
 
 const ConsentService = forwardRef((props, ref) => {
   const {
-    className,
-    description,
-    title,
     acceptLabel,
-    refuseLabel,
+    className,
     defaultConsent,
+    description,
+    disabled,
+    name,
+    onChange,
+    refuseLabel,
+    title,
     ...remainingProps
   } = props;
-  const _className = classNames('fr-consent-service ds-fr--border-bottom', className);
+  const _className = classNames(
+    'fr-consent-service ds-fr--border-bottom',
+    className,
+  );
   return (
     <div
       className={_className}
@@ -23,39 +29,47 @@ const ConsentService = forwardRef((props, ref) => {
     >
       <div className="fr-consent-service__radios">
         <RadioGroup
-          legend={title}
+          disabled={disabled}
           isInline
+          legend={title}
+          name={name}
+          onChange={onChange}
         >
           <Radio
-            label={acceptLabel}
-            value={`${acceptLabel.toLowerCase().replace(/\s+/g, '')}`}
             defaultChecked={defaultConsent === 'accept'}
+            disabled={disabled}
+            label={acceptLabel}
+            value="accept"
           />
           <Radio
-            label={refuseLabel}
-            value={`${refuseLabel.toLowerCase().replace(/\s+/g, '')}`}
             defaultChecked={defaultConsent === 'refuse'}
+            disabled={disabled}
+            label={refuseLabel}
+            value="refuse"
           />
         </RadioGroup>
       </div>
-      <p className="fr-consent-service__desc">
-        {description}
-      </p>
+      <p className="fr-consent-service__desc">{description}</p>
     </div>
   );
 });
 
 ConsentService.defaultProps = {
   description: '',
+  disabled: false,
   className: '',
+  onChange: () => null,
 };
 
 ConsentService.propTypes = {
+  acceptLabel: PropTypes.string.isRequired,
   className: PropTypes.string,
-  title: PropTypes.string.isRequired,
   defaultConsent: PropTypes.oneOf(['accept', 'refuse']).isRequired,
   description: PropTypes.string,
-  acceptLabel: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
   refuseLabel: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 export default ConsentService;

--- a/src/components/interface/ConsentManager/__tests__/__snapshots__/ConsentService.test.js.snap
+++ b/src/components/interface/ConsentManager/__tests__/__snapshots__/ConsentService.test.js.snap
@@ -33,7 +33,7 @@ exports[`<ConsentService /> should render ConsentService properly 1`] = `
               onChange={[Function]}
               required={false}
               type="radio"
-              value="toutaccepter"
+              value="accept"
             />
             <label
               className="fr-label"
@@ -50,7 +50,7 @@ exports[`<ConsentService /> should render ConsentService properly 1`] = `
               onChange={[Function]}
               required={false}
               type="radio"
-              value="toutrefuser"
+              value="refuse"
             />
             <label
               className="fr-label"


### PR DESCRIPTION
The old APIs do not allow to do actions such as handling the "deny all" in the modal. The modification will also make it possible to set up a hook to manage consents, their modifications and the management of the services used (analytics, integration of third-party services, etc.)

There is a breaking change in `ConsentManager`, i use the name insteadof the value as parameter to `confirmConsent`.
